### PR TITLE
[희열] Issue 탭 Status 필터링, 개수 반영

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # clean-fe-template
 
-### 설치순서
+## 설치순서
+
 ```shell
-git clone https://github.com/clean-fe/github-issues.git 
+git clone https://github.com/clean-fe/github-issues.git
 
 cd github-issues
 
@@ -10,3 +11,129 @@ npm install
 
 npm run dev
 ```
+
+# 1주차 : 함수를 활용한 애플리케이션
+
+## 목표
+
+### 1. 기능 요구사항 충족
+
+- [ ] 초기 로딩시에 위 화면과 같은 화면을 보여준다.
+
+  - [ ] 헤더영역에 opens, closed 갯수를 올바르게 표시
+  - [ ] 본문영역에 issue 리스트를 표시
+
+- [ ] opens , closed 버튼을 선택하면 각각 해당하는 내용을 노출.
+
+### 2. 구현 요구사항 충족
+
+2.1. 데이터 요청
+초기 데이터는 fetch 요청을 통해서 가져온다.
+URL : /data-sources/issues.json, labels.json
+
+2.2. 함수 사용
+
+- [ ] 배열의 고차함수 적극 사용.
+- [ ] 여러개의 작은 함수를 만들어야 함.
+  - [ ] 짧은 함수를 화살표 함수로 표현(람다표기법)
+- [ ] 중복 코드 최대한 없게.
+- [ ] 콜백함수도 가급적 분리
+- [ ] 함수 합성 시도하기.
+  - [ ] pipeline 방식.
+  - [ ] 필요하면 currying 기법으로 합성가능하도록 바인딩처리.
+
+### 3. ES Modules 활용
+
+- [ ] ES Modules을 사용
+- [ ] main.js 가 entry point 역할임. 그외 필요한 js 모듈(파일)을 생성해서 구현할 수 있음.
+
+### 4. 추가 목표
+
+- [ ] 함수형 프로그래밍의 개념과 적용을 이해한 문서
+- [ ] pipe, currying을 이해하고 사용
+- [ ] 페어 프로그래밍 경험
+
+## 설계
+
+---
+
+## 1차 회고
+
+```js
+const fetchItems = async (fetchCallback) => {
+  return await fetchCallback()
+}
+
+const templateRender = (items, getTempl) => {
+  return items.map(getTempl)
+}
+
+const createDOMwithItems = (items, className) => [document.querySelector(className), items],
+
+const executeRender = ([dom, cItems]) => render(dom, cItems);
+
+const renderComponent = async (fetchCallback, getTempl, className) => {
+  const processPipe = pipe(
+    () => fetchItems(fetchCallback),
+    (items) => templateRender(items, getTempl),
+    (items) => createDOMwithItems(items, className),
+    executeRender,
+  )()
+}
+```
+
+- 생각했던 함수가 아닌 것 같다.
+  - items만 넘기는 것을 구현한 것이 아닌지...
+  - 인자의 인터페이스가 통일되지 않는 것이 이상함.
+  - pipe 내부에 인자로 넘기는 함수를 좀 더 깔끔하게 할 수 있지 않을까 고민중...
+
+---
+
+## 2차 회고
+
+```js
+const fetchItems = (fetchCallback) => async () => {
+  return await fetchCallback()
+}
+const templateRender = (getTempl) => (items) => {
+  return items.map(getTempl)
+}
+
+const createDOMwithItems = (className) => (items) =>
+  render(document.querySelector(className), items)
+
+const renderComponent = async ({ fetchCallback, getTempl, className }) => {
+  pipe(
+    fetchItems(fetchCallback),
+    templateRender(getTempl),
+    createDOMwithItems(className),
+  )()
+}
+```
+
+### 희열
+
+- 처음하는 페어프로그래밍이라 당황스러웠는데, 빰빰님이 리딩을 잘 해줘서 잘 한 것 같습니다.
+- pipe를 실제로 구현하는 상황에서 복잡한 로직을 보느라
+  - 잘게 쪼개고,
+  - 고차함수를 사용하는 것을 연습하고자 합니다.
+
+### 빰빰
+
+- 균형된 지식 수준이 페어 작업을 가능하게 한 것 같습니다.
+- pipe가 완성되었다고 생각했는데, 계속 디벨롭해야하는 상황입니다.
+
+## 3차 pipe 예상
+
+```js
+const renderComponent = async (props) => {
+  const props = { fetchCallback, getTempl, className }
+
+  pipe(fetchItems, templateRender, createDOMwithItems)(props)
+}
+```
+
+---
+
+- compose vs. pipe
+- 함수형프로그래밍의 철학 (모나드 개념, 커링 개념)

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ URL : /data-sources/issues.json, labels.json
 - [ ] 중복 코드 최대한 없게.
 - [ ] 콜백함수도 가급적 분리
 - [ ] 함수 합성 시도하기.
-  - [ ] pipeline 방식.
+  - [x] pipeline 방식.
   - [ ] 필요하면 currying 기법으로 합성가능하도록 바인딩처리.
 
 ### 3. ES Modules 활용
@@ -57,7 +57,9 @@ URL : /data-sources/issues.json, labels.json
 
 ---
 
-## 1차 회고
+## 230403 월요일 회고 (페어 프로그래밍)
+
+### 1차 회고
 
 ```js
 const fetchItems = async (fetchCallback) => {
@@ -89,7 +91,7 @@ const renderComponent = async (fetchCallback, getTempl, className) => {
 
 ---
 
-## 2차 회고
+### 2차 회고
 
 ```js
 const fetchItems = (fetchCallback) => async () => {
@@ -123,7 +125,7 @@ const renderComponent = async ({ fetchCallback, getTempl, className }) => {
 - 균형된 지식 수준이 페어 작업을 가능하게 한 것 같습니다.
 - pipe가 완성되었다고 생각했는데, 계속 디벨롭해야하는 상황입니다.
 
-## 3차 pipe 예상
+### 3차 pipe 예상
 
 ```js
 const renderComponent = async (props) => {
@@ -137,3 +139,20 @@ const renderComponent = async (props) => {
 
 - compose vs. pipe
 - 함수형프로그래밍의 철학 (모나드 개념, 커링 개념)
+
+## 230404 화요일 회고
+
+```js
+export const asyncPipe = (...functions) => {
+  return (initialValue) => {
+    return functions.reduce(async (previousPromiseResult, currentFn) => {
+      return currentFn(await previousPromiseResult)
+    }, Promise.resolve(initialValue))
+  }
+}
+```
+
+- asyncPipe 내부의 previousPromiseResult에서 await가 필요한 이유가 확실히 이해가지 않았는데 그 이유에 대해 알게 되었고, 그 과정에서 고차함수, 파이프 라인, async-await에 대해서 더 깊게 이해할 수 있었다.
+- 아래는 스스로 던진 질문과 대답.
+  - Q. 왜 asyncPipe의 previousPromise를 await 해야하는가?
+  - A. 처음 함수가 실행된 후의 previousPromiseResult는 fetchItems가 반환한 함수의 결과이다. 그리고 그 결과는 Promise 객체이다. 그래서 다음 함수의 인자로 값을 전달하기 위해서는 Pipe 내부에서 await를 해야한다. 처음에는 fetchItems가 반환하는 함수를 async-await로 감싸면 되지 않을까 생각했지만, 어차피 이 함수의 결과값 또한 Promise가 되는 꼴이므로 Promise 객체를 반환하는 함수를 사용한다면 pipe 내부에서 await이나 Promise 메서드를 사용해서 결과값을 기다리고 다음 함수의 인자로 넘겨줘야 한다.

--- a/index.html
+++ b/index.html
@@ -1,28 +1,22 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Github App</title>
+    <link rel="stylesheet" type="text/css" href="src/style.css" />
+  </head>
 
-<head>
-  <meta charset="UTF-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Github App</title>
-  <link rel="stylesheet" type="text/css" href="src/style.css">
-</head>
-
-<body>
-
-  <nav class="flex justify-end py-8 w-full m-auto text-1xl bg-neutral-800" style="padding-right: 12.5rem;">
-    <button class="mr-4 base-outer p-2 px-5">Issue</button>
-    <button class="base-outer p-2 px-5">Label</button>
-  </nav>
-
-  <div id="app" class="py-8">
-  
-  </div>
-
-  <script type="module" src="./src/main.js"></script>
-  <script>
-
-  </script>
-</body>
-
+  <body>
+    <nav
+      class="flex justify-end py-8 w-full m-auto text-1xl bg-neutral-800"
+      style="padding-right: 12.5rem"
+    >
+      <button class="issue-button mr-4 base-outer p-2 px-5">Issue</button>
+      <button class="label-button base-outer p-2 px-5">Label</button>
+    </nav>
+    <div id="app" class="py-8"></div>
+    <script type="module" src="./src/main.js"></script>
+    <script></script>
+  </body>
 </html>

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,7 +1,6 @@
 const fetchData = async (url) => {
   const response = await fetch(url)
-  const json = await response.json()
-  return await json
+  return response.json()
 }
 
 const fetchIssues = () => fetchData('/data-sources/issues.json')

--- a/src/fetch.js
+++ b/src/fetch.js
@@ -1,0 +1,10 @@
+const fetchData = async (url) => {
+  const response = await fetch(url)
+  const json = await response.json()
+  return await json
+}
+
+const fetchIssues = () => fetchData('/data-sources/issues.json')
+const fetchLabels = () => fetchData('/data-sources/labels.json')
+
+export { fetchIssues, fetchLabels }

--- a/src/main.js
+++ b/src/main.js
@@ -7,7 +7,7 @@ import {
 import { fetchIssues, fetchLabels } from './fetch.js'
 import { navigateTo } from './navigation.js'
 
-import { pipe } from './util'
+import { pipe, asyncPipe } from './util'
 
 const appElement = document.querySelector('#app')
 
@@ -15,6 +15,7 @@ const render = (element, template) => {
   element.innerHTML = template.join('')
 }
 
+// Todo: 함수 두개 합치기
 const renderIssues = async () => {
   const issues = await fetchIssues()
   const issueItems = issues.map(getIssueItemTpl)
@@ -43,13 +44,13 @@ const renderObject = {
 }
 
 const fetchItems = (fetchCallback) => {
-  return async () => {
-    return await fetchCallback()
+  return () => {
+    return fetchCallback()
   }
 }
 
 const templateRender = (getTempl) => {
-  return async (items) => {
+  return (items) => {
     return items.map(getTempl)
   }
 }
@@ -61,8 +62,8 @@ const createDOMwithItems = (className) => {
   }
 }
 
-const renderComponent = async ({ fetchCallback, getTempl, className }) => {
-  pipe(
+const renderComponent = ({ fetchCallback, getTempl, className }) => {
+  asyncPipe(
     fetchItems(fetchCallback),
     templateRender(getTempl),
     createDOMwithItems(className),

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,96 @@
+import {
+  getIssueTpl,
+  getLabelTpl,
+  getIssueItemTpl,
+  getLabelItemTpl,
+} from './tpl.js'
+import { fetchIssues, fetchLabels } from './fetch.js'
+import { navigateTo } from './navigation.js'
+
+import { pipe } from './util'
+
+const appElement = document.querySelector('#app')
+
+const render = (element, template) => {
+  element.innerHTML = template.join('')
+}
+
+const renderIssues = async () => {
+  const issues = await fetchIssues()
+  const issueItems = issues.map(getIssueItemTpl)
+  const issueList = document.querySelector('.issue-list')
+  render(issueList, issueItems)
+}
+
+const renderLabels = async () => {
+  const labels = await fetchLabels()
+  const labelItems = labels.map(getLabelItemTpl)
+  const labelList = document.querySelector('.label-list')
+  render(labelList, labelItems)
+}
+
+const renderObject = {
+  issue: {
+    fetchCallback: fetchIssues,
+    getTempl: getIssueItemTpl,
+    className: '.issue-list',
+  },
+  label: {
+    fetchCallback: fetchLabels,
+    getTempl: getLabelItemTpl,
+    className: '.label-list',
+  },
+}
+
+const fetchItems = (fetchCallback) => {
+  return async () => {
+    return await fetchCallback()
+  }
+}
+
+const templateRender = (getTempl) => {
+  return async (items) => {
+    return items.map(getTempl)
+  }
+}
+
+const createDOMwithItems = (className) => {
+  return (items) => {
+    const list = document.querySelector(className)
+    render(list, items)
+  }
+}
+
+const renderComponent = async ({ fetchCallback, getTempl, className }) => {
+  pipe(
+    fetchItems(fetchCallback),
+    templateRender(getTempl),
+    createDOMwithItems(className),
+  )()
+}
+
+const navigate = (path) => {
+  navigateTo(path)
+
+  if (path === '/') {
+    appElement.innerHTML = getIssueTpl()
+    renderComponent(renderObject.issue)
+  }
+  if (path === '/label') {
+    appElement.innerHTML = getLabelTpl()
+    renderComponent(renderObject.label)
+  }
+}
+
+const init = () => {
+  const issueButton = document.querySelector('.issue-button')
+  const labelButton = document.querySelector('.label-button')
+
+  issueButton.addEventListener('click', () => navigate('/'))
+  labelButton.addEventListener('click', () => navigate('/label'))
+
+  const currentPath = window.location.pathname
+  navigate(currentPath)
+}
+
+init()

--- a/src/navigation.js
+++ b/src/navigation.js
@@ -1,0 +1,3 @@
+const navigateTo = (path) => window.history.pushState(null, '', path)
+
+export { navigateTo }

--- a/src/tpl.js
+++ b/src/tpl.js
@@ -29,8 +29,8 @@ export function getIssueTpl() {
         </div>
 
         <div class="statusTab flex">
-          <div class="whitespace-nowrap open-count font-bold cursor-pointer">0 Opens</div>
-          <div class="whitespace-nowrap close-count ml-3 cursor-pointer">0 Closed</div>
+          <button class="whitespace-nowrap open-count font-bold cursor-pointer">0 Opens</button>
+          <button class="whitespace-nowrap close-count ml-3 cursor-pointer">0 Closed</button>
         </div>
 
         <div class="details-list flex ml-auto">

--- a/src/tpl.js
+++ b/src/tpl.js
@@ -1,5 +1,5 @@
 export function getIssueTpl() {
-	return `
+  return `
     <div id="issue-wrapper" class="w-9/12 m-auto min-w-min">
     <div id="header" class="flex justify-between">
 
@@ -58,16 +58,16 @@ export function getIssueTpl() {
         </div>
 
       </div>
-      <div class="issue-list flex ml-auto">
+      <div class="issue-list ml-auto">
         <ul></ul>
       </div>
     </div>
   </div>
-    `;
+    `
 }
 
 export function getIssueItemTpl(item) {
-    return `
+  return `
         <li> 
           <div class="py-4">
               <input type="checkbox">
@@ -79,15 +79,17 @@ export function getIssueItemTpl(item) {
                     ${item.tags.reduce((html, { tagName, color }) => {
                       return `
                         ${html} <span class="rounded-lg border text-white p-1" style="background-color:${color}">${tagName}</span>
-                      `;
+                      `
                     }, ``)}
                   </div>
               </div>
               <div class="issue-description text-xs mt-2">
-                ${item._id} ${item.status}ed ${item['open-date']} ${item.milestones}
+                ${item._id} ${item.status}ed ${item['open-date']} ${
+    item.milestones
+  }
               </div>
           </div>
-        </li>`;
+        </li>`
 }
 
 export function getLabelTpl() {
@@ -225,7 +227,7 @@ export function getLabelTpl() {
 }
 
 export function getLabelItemTpl({ name, color, description }) {
-		return `
+  return `
             <li class="label-item flex items-center ml-4 py-3 justify-between border-b ">
                 <div class="issue-title flex"> 
                     <span class="rounded-lg border p-1 px-2" style="background-color:#${color}">${name}</span> 
@@ -237,5 +239,5 @@ export function getLabelItemTpl({ name, color, description }) {
                     <button class="delete-button">delete</button>
                 </div>
             </li>
-        `;
+        `
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,8 +1,15 @@
 export const pipe = (...functions) => {
-  return (args = undefined) => {
-    return functions.reduce(async (previousPromise, nextFn) => {
-      const arg = await previousPromise
-      return await nextFn(arg)
-    }, Promise.resolve(args))
+  return (initialValue) => {
+    return functions.reduce((previousResult, currentFn) => {
+      return currentFn(arg)
+    }, initialValue)
+  }
+}
+
+export const asyncPipe = (...functions) => {
+  return (initialValue) => {
+    return functions.reduce(async (previousPromiseResult, currentFn) => {
+      return currentFn(await previousPromiseResult)
+    }, Promise.resolve(initialValue))
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -1,0 +1,8 @@
+export const pipe = (...functions) => {
+  return (args = undefined) => {
+    return functions.reduce(async (previousPromise, nextFn) => {
+      const arg = await previousPromise
+      return await nextFn(arg)
+    }, Promise.resolve(args))
+  }
+}


### PR DESCRIPTION
# 반영한 것
- 필요없는 코드를 삭제했습니다.
- updateIssueCount 함수를 파이프 라인에 추가해서 Status에 따른 필터링을 반영했습니다.

# 반영하고 싶은 것
- renderObject에서 status에 접근해서 상태를 변경해주고 있는데, 이 방식이 적절해보이지는 않습니다.
- 파이프라인, 기능 구현까지는 했지만 다른 함수가 적절한 단위로 쪼개져 있지 않습니다.
- module이 적절히 분리되어 있지 않습니다.
- Status를 할 때 마다 파이프라인에서 fetch를 다시 하고있는데 이 부분을 상태로 어떻게 관리할지 고민중입니다.